### PR TITLE
Fixes uncaught exception from trying to recopy when "run.sh" is not f…

### DIFF
--- a/cm_boot.py
+++ b/cm_boot.py
@@ -407,7 +407,7 @@ def _unpack_cm():
     log.info(('<< Unpacking CloudMan from %s >>' % local_path))
     tar = tarfile.open(local_path, 'r:gz')
     tar.extractall(CM_HOME)
-    if ('run.sh' not in tar.getnames()):
+    if ('run.sh' not in tar.getnames() or './run.sh' not in tar.getnames()):
         first_entry = tar.getnames()[0]
         extracted_dir = first_entry.split('/')[0]
         for extracted_file in os.listdir(os.path.join(CM_HOME, extracted_dir)):

--- a/cm_boot.py
+++ b/cm_boot.py
@@ -407,7 +407,7 @@ def _unpack_cm():
     log.info(('<< Unpacking CloudMan from %s >>' % local_path))
     tar = tarfile.open(local_path, 'r:gz')
     tar.extractall(CM_HOME)
-    if ('run.sh' not in tar.getnames() or './run.sh' not in tar.getnames()):
+    if ('run.sh' not in tar.getnames() and './run.sh' not in tar.getnames()):
         first_entry = tar.getnames()[0]
         extracted_dir = first_entry.split('/')[0]
         for extracted_file in os.listdir(os.path.join(CM_HOME, extracted_dir)):


### PR DESCRIPTION
…ound

During the unpacking subroutine of the boot script, the tarfile's contents are extracted to the CM_HOME directory. Then, the function checks is "run.sh" is in the tar files contents. `run.sh` is not found (at least in CentOS style operating systems) in the package contents, whereas `./run.sh` is available. This issue leads to the function trying to move files to locations that already have contents at this point, and an uncaught exception from shutil

```
2015-11-02 11:01:52,487 INFO   cm_boot:412 - << Unpacking CloudMan from /mnt/cm/cm.tar.gz >>
Traceback (most recent call last):
  File "/opt/cloudman/boot/cm_boot.py", line 529, in <module>
    main()
  File "/opt/cloudman/boot/cm_boot.py", line 525, in main
    _start(ud)
  File "/opt/cloudman/boot/cm_boot.py", line 472, in _start
    _unpack_cm()
  File "/opt/cloudman/boot/cm_boot.py", line 419, in _unpack_cm
    shutil.move(os.path.join(CM_HOME, extracted_dir, extracted_file), CM_HOME)
  File "/usr/lib64/python2.6/shutil.py", line 250, in move
    raise Error, "Destination path '%s' already exists" % real_dst
shutil.Error: Destination path '/mnt/cm/installed_files' already exists
> python
Python 2.6.6 (r266:84292, Jul 23 2015, 15:22:56) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-11)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> import tarfile
>>> tar = tarfile.open("/mnt/cm/cm.tar.gz",'r:gz')
>>> files=tar.getnames()
>>> files
['./CHANGELOG.md', './cm', './cm/__init__.py', './cm/app.py', './cm/base', './cm/base/__init__.py', './cm/base/controller.py', './cm/boot', './cm/boot/__init__.py', './cm/boot/conf.py', './cm/boot/object_store.py', './cm/boot/util.py', './cm/buildapp.py', './cm/clouds', './cm/clouds/__init__.py', './cm/clouds/cloud_config.py', './cm/clouds/dummy.py', './cm/clouds/ec2.py', './cm/clouds/eucalyptus.py', './cm/clouds/opennebula.py', './cm/clouds/openstack.py', './cm/config.py', './cm/conftemplates', './cm/conftemplates/__init__.py', './cm/conftemplates/condor_master_config.default', './cm/conftemplates/condor_worker_config.default', './cm/conftemplates/conf_manager.py', './cm/conftemplates/nginx.conf.default', './cm/conftemplates/nginx1.4.conf.default', './cm/conftemplates/nginx_cloudera_manager_locations.default', './cm/conftemplates/nginx_cloudgene_locations.default', './cm/conftemplates/nginx_default_locations.default', './cm/conftemplates/nginx_galaxy_locations.default', './cm/conftemplates/nginx_galaxy_reports_locations.default', './cm/conftemplates/nginx_server.default', './cm/conftemplates/nginx_server_pulsar.default', './cm/conftemplates/nginx_server_ssl.default', './cm/conftemplates/proftpd.conf.default', './cm/conftemplates/sge_all.q.conf.default', './cm/conftemplates/sge_host_conf_template.default', './cm/conftemplates/sge_install_template.default', './cm/conftemplates/sge_mpi_pe.default', './cm/conftemplates/sge_request_template.default', './cm/conftemplates/sge_smp_pe.default', './cm/conftemplates/slurm.conf.default', './cm/conftemplates/supervisord.conf.default', './cm/controllers', './cm/controllers/__init__.py', './cm/controllers/root.py', './cm/framework', './cm/framework/__init__.py', './cm/framework/base.py', './cm/framework/helpers', './cm/framework/helpers/__init__.py', './cm/framework/messages', './cm/framework/messages/__init__.py', './cm/framework/messages/api.py', './cm/framework/messages/constants.py', './cm/framework/messages/storage', './cm/framework/messages/storage/__init__.py', './cm/framework/messages/storage/base.py', './cm/framework/messages/storage/local.py', './cm/framework/messages/utils.py', './cm/framework/middleware', './cm/framework/middleware/__init__.py', './cm/framework/middleware/profile.py', './cm/framework/middleware/static.py', './cm/framework/middleware/xforwardedhost.py', './cm/instance.py', './cm/master.py', './cm/services', './cm/services/__init__.py', './cm/services/apps', './cm/services/apps/__init__.py', './cm/services/apps/clouderamanager.py', './cm/services/apps/cloudgene.py', './cm/services/apps/galaxy.py', './cm/services/apps/galaxyreports.py', './cm/services/apps/hadoop.py', './cm/services/apps/htcondor.py', './cm/services/apps/jobmanagers', './cm/services/apps/jobmanagers/__init__.py', './cm/services/apps/jobmanagers/sge.py', './cm/services/apps/jobmanagers/sgeinfo.py', './cm/services/apps/jobmanagers/slurmctld.py', './cm/services/apps/jobmanagers/slurmd.py', './cm/services/apps/jobmanagers/slurminfo.py', './cm/services/apps/migration.py', './cm/services/apps/nginx.py', './cm/services/apps/nodejsproxy.py', './cm/services/apps/postgres.py', './cm/services/apps/proftpd.py', './cm/services/apps/pss.py', './cm/services/apps/pulsar.py', './cm/services/apps/supervisor.py', './cm/services/autoscale.py', './cm/services/data', './cm/services/data/__init__.py', './cm/services/data/bucket.py', './cm/services/data/filesystem.py', './cm/services/data/mountablefs.py', './cm/services/data/transient_storage.py', './cm/services/data/volume.py', './cm/services/registry.py', './cm/util', './cm/util/__init__.py', './cm/util/bunch.py', './cm/util/comm.py', './cm/util/decorators.py', './cm/util/galaxy_conf.py', './cm/util/manager.py', './cm/util/misc.py', './cm/util/nfs_export.py', './cm/util/paths.py', './cm/worker.py', './cm_boot.py', './cm_cluster_config.yaml', './cm_wsgi.ini', './cm_wsgi.ini.sample', './dev_requirements.txt', './installed_files', './installed_files/datatypes_conf.xml.cloud', './installed_files/shed_tool_conf.xml.cloud', './installed_files/tool_conf.xml.cloud', './installed_files/tool_data_table_conf.xml.cloud', './installed_files/universe_wsgi.ini.cloud', './make_boot_script.py', './persistent_data.yaml.sample', './README.md', './requirements.txt', './run.sh', './scripts', './scripts/check_python.py', './scripts/paster.py', './setup.cfg', './setup.py', './setup.sh', './snaps.yaml.sample', './static', './static/favicon.ico', './static/fonts', './static/fonts/FontAwesome.otf', './static/fonts/fontawesome-webfont.eot', './static/fonts/fontawesome-webfont.svg', './static/fonts/fontawesome-webfont.ttf', './static/fonts/fontawesome-webfont.woff', './static/fonts/fontawesome-webfont.woff2', './static/images', './static/images/GC2_power_button.png', './static/images/ajax_loader.gif', './static/images/ajax_loader_large.gif', './static/images/bluebox.png', './static/images/cancel.png', './static/images/cloudmanIcon_noText.png', './static/images/delete_icon.png', './static/images/delete_icon_dark.png', './static/images/delete_icon_red.png', './static/images/disc-pencil-bw.png', './static/images/disc-pencil.png', './static/images/disc_plus.png', './static/images/disc_plus_bw.png', './static/images/downarrow.png', './static/images/error_message_icon.png', './static/images/fugue', './static/images/fugue/control.png', './static/images/fugue/cross-button.png', './static/images/fugue/share.png', './static/images/fugue/status-away.png', './static/images/fugue/status-busy.png', './static/images/fugue/status-offline.png', './static/images/fugue/status.png', './static/images/fugue/toggle-expand.png', './static/images/fugue/toggle-small-expand.png', './static/images/fugue/toggle-small.png', './static/images/fugue/toggle.png', './static/images/galaxyIcon_noText.png', './static/images/gc2_icon.png', './static/images/greenbox.png', './static/images/minus_large.png', './static/images/overlay.png', './static/images/persist.png', './static/images/persist_bw.png', './static/images/plus_large.png', './static/images/plus_minus.png', './static/images/plus_minus_large.png', './static/images/reboot.png', './static/images/redbox.png', './static/images/terminate.png', './static/images/tipsy.gif', './static/images/warn_message_icon.png', './static/images/yellowbox.png', './static/scripts', './static/scripts/Backbone.ModalDialog.js', './static/scripts/IE7.js', './static/scripts/IE8.js', './static/scripts/admin.js', './static/scripts/backbone-min.js', './static/scripts/backbone.js', './static/scripts/backbone.marionette.js', './static/scripts/backbone.marionette.min.js', './static/scripts/cluster_canvas.js', './static/scripts/ie7-recalc.js', './static/scripts/jQuery-1.4.2.js', './static/scripts/jquery-1.7.1.min.js', './static/scripts/jquery-ui-1.8.10.custom.min.js', './static/scripts/jquery.form.js', './static/scripts/jquery.stopwatch.js', './static/scripts/jquery.tipsy.js', './static/scripts/livevalidation_standalone.compressed.js', './static/scripts/underscore-min.js', './static/scripts/underscore.js', './static/style', './static/style/base.css', './static/style/base.css.tmpl', './static/style/base_bg.png', './static/style/blue_colors.ini', './static/style/font-awesome.min.css', './static/style/footer_title_bg.png', './static/style/gradient.py', './static/style/masthead.css', './static/style/masthead.css.tmpl', './static/style/masthead_bg.png', './static/style/minibar.css', './static/style/report_title_bg.png', './templates', './templates/admin.mako', './templates/base_panels.mako', './templates/bits', './templates/bits/messages.html', './templates/clouds', './templates/clouds/amazon', './templates/clouds/amazon/user_data.sample.yaml', './templates/clouds/hpcloud', './templates/clouds/hpcloud/user_data.yaml.sample', './templates/clouds/ict-tas', './templates/clouds/ict-tas/user_data.yaml.sample', './templates/clouds/nectar', './templates/clouds/nectar/user_data.yaml.sample', './templates/cluster_status.mako', './templates/gc2_combined.mako', './templates/index.mako', './templates/instance_feed.mako', './templates/instance_types.mako', './templates/log.mako', './templates/masthead.mako', './templates/mini_control.mako', './templates/srvc_log.mako', './templates/worker_index.mako', './test', './test/test_boot_conf.py', './test/test_boot_object_store.py', './test/test_boot_util.py', './test/test_galaxy_conf.py', './test/test_master_instance.py', './test/test_paths.py', './test/test_service_lwr.py', './test/test_universe_application.py', './test/test_utils.py', './TESTING.md', './userData.yaml.sample']
>>>
```
